### PR TITLE
Fixed unresponsive Netty on unaccepted request

### DIFF
--- a/bridge-netty4/src/main/java/org/atmosphere/vibe/platform/bridge/netty4/VibeServerCodec.java
+++ b/bridge-netty4/src/main/java/org/atmosphere/vibe/platform/bridge/netty4/VibeServerCodec.java
@@ -78,6 +78,7 @@ public class VibeServerCodec extends ChannelInboundHandlerAdapter {
         if (msg instanceof HttpRequest) {
             HttpRequest req = (HttpRequest) msg;
             if (!accept(req)) {
+                ctx.fireChannelRead(msg);
                 return;
             }
             if (req.getMethod() == HttpMethod.GET && req.headers().contains(HttpHeaders.Names.UPGRADE, HttpHeaders.Values.WEBSOCKET, true)) {


### PR DESCRIPTION
When an request is not accepted the next ChannelHandler is not invoked and Netty does nothing with the request. This change hands a not accepted request to the next ChannelHandler in the pipeline.
